### PR TITLE
Make the billing address look less important

### DIFF
--- a/pyvecorg/templates/index.html
+++ b/pyvecorg/templates/index.html
@@ -206,18 +206,18 @@
             <div class="container">
                 <div class="row">
                     <div class="col address">
-                        <h3>{{ meta.billing_address.heading }}</h3>
-                        {{ meta.billing_address.directions|markdown }}
-                        <p>
-                            {{ meta.reg_no.label }}: <a href="http://wwwinfo.mfcr.cz/cgi-bin/ares/darv_res.cgi?ico={{ meta.reg_no.value }}&amp;xml=1{% if lang == 'en' %}&amp;jazyk=en{% endif %}">{{ meta.reg_no.value }}</a><br>
-                        </p>
-                    </div>
-                    <div class="w-100 d-block d-md-none"></div>
-                    <div class="col address">
                         <h3>{{ meta.address.heading }}</h3>
                         {{ meta.address.directions|markdown }}
                         <p>
                             E-mail: <a href="mailto:info@pyvec.org">info@pyvec.org</a>
+                        </p>
+                    </div>
+                    <div class="w-100 d-block d-md-none"></div>
+                    <div class="col address">
+                        <h3>{{ meta.billing_address.heading }}</h3>
+                        {{ meta.billing_address.directions|markdown }}
+                        <p>
+                            {{ meta.reg_no.label }}: <a href="http://wwwinfo.mfcr.cz/cgi-bin/ares/darv_res.cgi?ico={{ meta.reg_no.value }}&amp;xml=1{% if lang == 'en' %}&amp;jazyk=en{% endif %}">{{ meta.reg_no.value }}</a><br>
                         </p>
                     </div>
                     <div class="w-100 d-block d-md-none"></div>


### PR DESCRIPTION
We want people to prefer the "address" over the "billing address" whenever possible. I switched their order so the billing address is in the second column.