### PR TITLE
Load YAML with yaml.safe_load

### DIFF
--- a/pyvecorg/data.py
+++ b/pyvecorg/data.py
@@ -13,7 +13,7 @@ def load_data():
         name, ext = os.path.splitext(basename)
         if ext in ['.yml', '.yaml']:
             with open(os.path.join(DATA_PATH, basename)) as f:
-                data[name] = yaml.load(f)
+                data[name] = yaml.safe_load(f)
     return data
 
 

--- a/tests/test_python_version.py
+++ b/tests/test_python_version.py
@@ -8,7 +8,7 @@ def test_python_version():
     project_dir = os.path.join(os.path.dirname(__file__), '..')
 
     with open(os.path.join(project_dir, '.travis.yml')) as f:
-        travis_py_version = yaml.load(f)['python'][0]
+        travis_py_version = yaml.safe_load(f)['python'][0]
 
     pipfile_data = pipfile.load(os.path.join(project_dir, 'Pipfile')).data
     pipfile_py_version = pipfile_data['_meta']['requires']['python_version']


### PR DESCRIPTION
The `yaml.load` function is not safe to use on untrusted data (in
currently released versions of PyYAML).

Our data is trusted, but it's still good to use safe_load
everywhere – if only as an example for copy-pasters.