### PR TITLE
Use the first grammatical case

### DIFF
--- a/pyvecorg/data/objectives.yml
+++ b/pyvecorg/data/objectives.yml
@@ -9,7 +9,7 @@ entries:
       en: "**Networking of experts** and their contact with the **international** community"
   - icon: graduation-cap
     text:
-      cs: "**Výuku programování** na základě **otevřených** materiálů"
+      cs: "**Výuka programování** na základě **otevřených** materiálů"
       en: "**Education of programming** based on **open** materials"
   - icon: female
     text:


### PR DESCRIPTION
It sounds better if one overlooks the heading.