### PR TITLE
Remove NePyvo from projects

### DIFF
--- a/pyvecorg/data/projects.yml
+++ b/pyvecorg/data/projects.yml
@@ -63,7 +63,7 @@ entries:
         networking, or education. Organized monthly.
     pyvec_help: [reimbursement, interconnection]
 
-  - name: PyWorking, NePyvo
+  - name: PyWorking
     url: https://pyworking.cz/
     logo: img/projects/pyworking.svg
     photo: pyworking


### PR DESCRIPTION
The meetups haven't been going on for a while, and have been basically replaced by PyWorking.