### PR TITLE
Download the list of members from Google Spreadsheet, download avatars as files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
             pip install pipenv --upgrade
             pipenv install --dev
       - run:
+          name: build data
+          command: pipenv run build
+      - run:
           name: run tests
           command: pipenv run test
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,15 @@
-# Elsa output
-_build
-
-### OSX
+# OS
+._*
 *.DS_Store
 
-# Icon must end with two \r
-Icon
-
-# Thumbnails
-._*
-
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
-
-# User-specific stuff:
+# IDEs
 .idea
+.vscode
+
+# Cache
+.cache
+.pytest_cache
+
+# Generated
+/pyvecorg/_build
+/pyvecorg/data/members_list.yml

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 # Generated
 /pyvecorg/_build
 /pyvecorg/data/members_list.yml
+/pyvecorg/static/img/avatars

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 /pyvecorg/_build
 /pyvecorg/data/members_list.yml
 /pyvecorg/static/img/avatars
+
+# Private
+google_service_account.json

--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,8 @@ pyyaml = "~=5.1"
 requests = "~=2.22.0"
 python-slugify = "~=3.0.2"
 pillow = "~=6.1.0"
+gspread = "~=3.1.0"
+oauth2client = "~=4.1.3"
 
 [dev-packages]
 # Pinning packages with ~= unless their version starts with 0.,

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [scripts]
+build = "python pyvecorg/build.py"
 test = "pytest"
 freeze = "python pyvecorg freeze"
 serve = "python pyvecorg serve"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f5d0983d2ac89e2fe55733d1b7ad346fead0d02aeaac89b4f735776d206c25b4"
+            "sha256": "fca06590b9d6ea98aa80b27c90fab97c9266d57d6cc348bde0c1b231cc503915"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -66,6 +66,21 @@
             ],
             "version": "==0.5.5"
         },
+        "gspread": {
+            "hashes": [
+                "sha256:dd945e3ae5d3d0325ad9982e0d5667f79ca121d0bb6f35274dc84371bbb79dd5",
+                "sha256:f7ce6c06250f694976c3cd4944e3b607b0810b93383839e5b67c7199ce2f0d3d"
+            ],
+            "index": "pypi",
+            "version": "==3.1.0"
+        },
+        "httplib2": {
+            "hashes": [
+                "sha256:6901c8c0ffcf721f9ce270ad86da37bc2b4d32b8802d4a9cec38274898a64044",
+                "sha256:cf6f9d5876d796539ec922a2c9b9a7cad9bfd90f04badcdc3bcfa537168052c3"
+            ],
+            "version": "==0.13.1"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
@@ -128,6 +143,14 @@
             ],
             "version": "==1.1.1"
         },
+        "oauth2client": {
+            "hashes": [
+                "sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac",
+                "sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6"
+            ],
+            "index": "pypi",
+            "version": "==4.1.3"
+        },
         "pillow": {
             "hashes": [
                 "sha256:0804f77cb1e9b6dbd37601cee11283bba39a8d44b9ddb053400c58e0c0d7d9de",
@@ -159,6 +182,20 @@
             ],
             "index": "pypi",
             "version": "==6.1.0"
+        },
+        "pyasn1": {
+            "hashes": [
+                "sha256:3bb81821d47b17146049e7574ab4bf1e315eb7aead30efe5d6a9ca422c9710be",
+                "sha256:b773d5c9196ffbc3a1e13bdf909d446cad80a039aa3340bcad72f395b76ebc86"
+            ],
+            "version": "==0.4.6"
+        },
+        "pyasn1-modules": {
+            "hashes": [
+                "sha256:43c17a83c155229839cc5c6b868e8d0c6041dba149789b6d6e28801c64821722",
+                "sha256:e30199a9d221f1b26c885ff3d87fd08694dbbe18ed0e8e405a2a7126d30ce4c0"
+            ],
+            "version": "==0.2.6"
         },
         "python-slugify": {
             "hashes": [
@@ -193,6 +230,20 @@
             ],
             "index": "pypi",
             "version": "==2.22.0"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66",
+                "sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487"
+            ],
+            "version": "==4.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
         },
         "text-unidecode": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Pyvec members are tracked in an internal Google Spreadsheet. The future
 intention is to have the list of members public, but we're not there yet (GDPR).
 So far only board members are being listed publicly. The `pipenv run build`
 command downloads the spreadsheet as CSV and generates the `members_list.yml`
-file.
+file. It also downloads and caches avatars.
 
 ### Numbers
 

--- a/README.md
+++ b/README.md
@@ -17,25 +17,41 @@ $ pipenv install
 The site uses [elsa](https://github.com/pyvec/elsa).
 
 - Installation: `pipenv install --dev`
-- Development server: `pipenv run serve`
+- Download data from external sources: `pipenv run build`
 - Tests: `pipenv run test`
+- Development server: `pipenv run serve`
 
 ### Data and tests
 
 The site is just a single HTML page rendered on top of some static data.
-However, the data can get quite complex and most of the texts need to be
-translated into two languages.
+However, some of the data come from external sources, the data can get quite
+complex, and most of the texts need to be translated into two languages.
 
 The data is stored in multiple YAML files. When these are read, whenever
 an object has just `cs` and `en` properties, it is treated as a "translated text"
 and the property corresponding to a currently selected language becomes
 the actual value in place of the object.
 
-Also, to keep the complex structure of the YAML files organized and tested,
-there are schemas written in [JSON Schema](https://spacetelescope.github.io/understanding-json-schema/)
+To keep the complex structure of the YAML files organized and tested,
+there are schemas written in [JSON Schema](https://json-schema.org/understanding-json-schema/)
 ([spec](http://json-schema.org/)). In tests, the YAML files are validated
 against the schemas. There is also a couple of additional tests to ensure some
 logical rules which cannot be easily expressed by JSON Schema.
+
+### External sources
+
+Some data cannot be stored statically in a YAML file. There is a command
+`pipenv run build`, which downloads them from external sources and generates
+respective static YAML files. This is a separate step, which needs to be done
+before developing or deploying the site, otherwise it won't work properly.
+
+### Members
+
+Pyvec members are tracked in an internal Google Spreadsheet. The future
+intention is to have the list of members public, but we're not there yet (GDPR).
+So far only board members are being listed publicly. The `pipenv run build`
+command downloads the spreadsheet as CSV and generates the `members_list.yml`
+file.
 
 ### Numbers
 

--- a/README.md
+++ b/README.md
@@ -68,14 +68,6 @@ the number,
 1. ask him to run the script,
 2. bother him to Open Source the script code.
 
-### Twitter avatars
-
-To figure out correct URLs of Twitter avatars from Twitter usernames, the site
-needs to perform an HTTP request for each of them. This is not really an issue,
-because on production this is done only once - in the moment of deployment.
-However, it can get very annoying during development. Set `DISABLE_TWITTER_AVATARS`
-environment variable to truthy value to disable Twitter avatars for development.
-
 ## Deployment
 
 The site uses [elsa](https://github.com/pyvec/elsa). It gets automatically deployed

--- a/README.md
+++ b/README.md
@@ -66,7 +66,16 @@ as well as it clones and analyzes all relevant repositories. If you need to upda
 the number,
 
 1. ask him to run the script,
-2. bother him to Open Source the script code.
+1. bother him to Open Source the script code.
+
+### Google Drive credentials
+
+1.  Follow the steps in the [gspread guide](https://gspread.readthedocs.io/en/latest/oauth2.html). Instead of Google Drive API, enable Google Sheets API.
+1.  Save the obtained JSON file into the `pyvecorg` package as `google_service_account.json`
+1.  Make sure it is ignored by Git
+1.  Run `cat pyvecorg/google_service_account.json | pbcopy` to copy the JSON into your clipboard (macOS)
+1.  Go to [Travis CI project settings](https://travis-ci.org/pyvec/pyvec.org/settings), section Environment Variables
+1.  Add `GOOGLE_SERVICE_ACCOUNT` variable and paste the JSON from your clipboard as a value
 
 ## Deployment
 

--- a/pyvecorg/__init__.py
+++ b/pyvecorg/__init__.py
@@ -1,4 +1,3 @@
-import os
 import itertools
 from pathlib import Path
 
@@ -27,8 +26,8 @@ app = Flask('pyvecorg')
 app.config['JSON_AS_ASCII'] = False
 
 
-from pyvecorg import views
-from pyvecorg import templating
+from pyvecorg import views  # noqa
+from pyvecorg import templating  # noqa
 
 
 __all__ = ['app', 'views', 'templating']

--- a/pyvecorg/avatars.py
+++ b/pyvecorg/avatars.py
@@ -19,8 +19,6 @@ def get_avatar_url(member):
         email_hash = hashlib.md5(value.lower().strip().encode()).hexdigest()
         return f'https://www.gravatar.com/avatar/{email_hash}?size=100&d=404'
     elif key == 'twitter':
-        if os.getenv('DISABLE_TWITTER_AVATARS'):
-            return no_avatar
         username = quote(value)
         url = f'https://twitter.com/{username}/profile_image'
         url = requests.head(url).headers.get('location')

--- a/pyvecorg/avatars.py
+++ b/pyvecorg/avatars.py
@@ -1,4 +1,3 @@
-import os
 import io
 from urllib.parse import quote
 import hashlib

--- a/pyvecorg/build.py
+++ b/pyvecorg/build.py
@@ -1,14 +1,18 @@
+import io
 import csv
 from pathlib import Path
 
 import yaml
 import requests
+from slugify import slugify
 
-from pyvecorg.avatars import get_avatar_url
+from pyvecorg.avatars import get_avatar_url, create_thumbnail
 
 
 MEMBERS_LIST_YAML = Path(__file__).parent / 'data' / 'members_list.yml'
-CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSWK18MlEy95sAGl1BM6BXWxPgJbIx2UH3tAyJjxES06hHuaXgpsmD5pRz9kkGcFupiZL_U_e7yv4t1/pub?gid=0&single=true&output=csv'  # noqa
+MEMBERS_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSWK18MlEy95sAGl1BM6BXWxPgJbIx2UH3tAyJjxES06hHuaXgpsmD5pRz9kkGcFupiZL_U_e7yv4t1/pub?gid=0&single=true&output=csv'  # noqa
+STATIC_DIR = Path(__file__).parent / 'static'
+AVATARS_DIR = STATIC_DIR / 'img' / 'avatars'
 
 
 def parse_members_csv(content):
@@ -35,12 +39,29 @@ def generate_yaml(data):
 
 
 if __name__ == '__main__':
-    # Build data/members_list.yml
-    response = requests.get(CSV_URL)
+    # Build data/members_list.yml and avatar images
+    response = requests.get(MEMBERS_CSV_URL)
     response.raise_for_status()
-    members = (
-        dict(avatar_url=get_avatar_url(member), **member) for member
+
+    members = [
+        member for member
         in parse_members_csv(response.content.decode('utf-8'))
-    )
+        if member.get('role')  # currently we only display members with role
+    ]
+
+    AVATARS_DIR.mkdir(exist_ok=True)
+    for member in members:
+        avatar_url = get_avatar_url(member)
+        img_basename = slugify(member['name']) + '.png'
+
+        response = requests.get(avatar_url)
+        response.raise_for_status()
+        img_bytes = create_thumbnail(io.BytesIO(response.content), 100).read()
+
+        img_path = (AVATARS_DIR / img_basename)
+        img_path.write_bytes(img_bytes)
+
+        member['avatar_filename'] = str(img_path.relative_to(STATIC_DIR))
+
     data = dict(entries=list(members))
     MEMBERS_LIST_YAML.write_text(generate_yaml(data))

--- a/pyvecorg/build.py
+++ b/pyvecorg/build.py
@@ -1,0 +1,41 @@
+import csv
+from pathlib import Path
+
+import yaml
+import requests
+
+
+MEMBERS_LIST_YAML = Path(__file__).parent / 'data' / 'members_list.yml'
+CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSWK18MlEy95sAGl1BM6BXWxPgJbIx2UH3tAyJjxES06hHuaXgpsmD5pRz9kkGcFupiZL_U_e7yv4t1/pub?gid=0&single=true&output=csv'  # noqa
+
+
+def parse_members_csv(content):
+    lines = content.splitlines()
+    rows = csv.reader(lines, delimiter=',')
+
+    head = None
+    for row in rows:
+        if frozenset(['name', 'role', 'avatar']) < frozenset(row):
+            head = row
+            break
+    for row in rows:
+        yield {key: value for key, value in zip(head, row) if value != ''}
+
+
+def generate_yaml(data):
+    yaml_contents = '''\
+#
+#  This file has been generated from external sources
+#  using `pipenv run build`. Do not edit it manually!
+#
+'''
+    return yaml_contents + yaml.dump(data, allow_unicode=True)
+
+
+if __name__ == '__main__':
+    # Build data/members_list.yml
+    response = requests.get(CSV_URL)
+    response.raise_for_status()
+    members = parse_members_csv(response.content.decode('utf-8'))
+    data = dict(entries=list(members))
+    MEMBERS_LIST_YAML.write_text(generate_yaml(data))

--- a/pyvecorg/build.py
+++ b/pyvecorg/build.py
@@ -1,6 +1,7 @@
 import io
 import os
 import json
+from textwrap import dedent
 from pathlib import Path
 
 import yaml
@@ -42,12 +43,12 @@ def parse_members(rows):
 
 
 def generate_yaml(data):
-    yaml_contents = '''\
-#
-#  This file has been generated from external sources
-#  using `pipenv run build`. Do not edit it manually!
-#
-'''
+    yaml_contents = dedent('''\
+        #
+        #  This file has been generated from external sources
+        #  using `pipenv run build`. Do not edit it manually!
+        #
+    ''')
     return yaml_contents + yaml.dump(data, allow_unicode=True)
 
 
@@ -57,6 +58,8 @@ if __name__ == '__main__':
     gsa_json = os.getenv('GOOGLE_SERVICE_ACCOUNT') or gsa_path.read_text()
     gsa = json.loads(gsa_json)
 
+    # Document key appears in the URL if you have the document open in your
+    # browser
     doc_key = '1n8hzBnwZ5ANkUCvwEy8rWsXlqeAAwu-5JBodT5OJx_I'
     rows = read_spreadsheet(doc_key, 'list', gsa)
     members = [member for member in parse_members(rows)

--- a/pyvecorg/build.py
+++ b/pyvecorg/build.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import yaml
 import requests
 
+from pyvecorg.avatars import get_avatar_url
+
 
 MEMBERS_LIST_YAML = Path(__file__).parent / 'data' / 'members_list.yml'
 CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSWK18MlEy95sAGl1BM6BXWxPgJbIx2UH3tAyJjxES06hHuaXgpsmD5pRz9kkGcFupiZL_U_e7yv4t1/pub?gid=0&single=true&output=csv'  # noqa
@@ -36,6 +38,9 @@ if __name__ == '__main__':
     # Build data/members_list.yml
     response = requests.get(CSV_URL)
     response.raise_for_status()
-    members = parse_members_csv(response.content.decode('utf-8'))
+    members = (
+        dict(avatar_url=get_avatar_url(member), **member) for member
+        in parse_members_csv(response.content.decode('utf-8'))
+    )
     data = dict(entries=list(members))
     MEMBERS_LIST_YAML.write_text(generate_yaml(data))

--- a/pyvecorg/data/definitions/member_schema.json
+++ b/pyvecorg/data/definitions/member_schema.json
@@ -24,13 +24,13 @@
     "avatar": {
       "type": "string"
     },
-    "avatar_url": {
+    "avatar_filename": {
       "type": "string"
     }
   },
   "additionalProperties": false,
   "required": [
     "name",
-    "avatar_url"
+    "avatar_filename"
   ]
 }

--- a/pyvecorg/data/definitions/member_schema.json
+++ b/pyvecorg/data/definitions/member_schema.json
@@ -5,6 +5,9 @@
     "name": {
       "type": "string"
     },
+    "nickname": {
+      "type": "string"
+    },
     "role": {
       "type": "string"
     },
@@ -25,6 +28,12 @@
       "type": "string"
     },
     "avatar_filename": {
+      "type": "string"
+    },
+    "address": {
+      "type": "string"
+    },
+    "dob": {
       "type": "string"
     }
   },

--- a/pyvecorg/data/definitions/member_schema.json
+++ b/pyvecorg/data/definitions/member_schema.json
@@ -27,8 +27,6 @@
   },
   "additionalProperties": false,
   "required": [
-    "name",
-    "role",
-    "avatar"
+    "name"
   ]
 }

--- a/pyvecorg/data/definitions/member_schema.json
+++ b/pyvecorg/data/definitions/member_schema.json
@@ -23,10 +23,14 @@
     },
     "avatar": {
       "type": "string"
+    },
+    "avatar_url": {
+      "type": "string"
     }
   },
   "additionalProperties": false,
   "required": [
-    "name"
+    "name",
+    "avatar_url"
   ]
 }

--- a/pyvecorg/data/members.yml
+++ b/pyvecorg/data/members.yml
@@ -2,75 +2,6 @@ heading:
   cs: Kdo je Pyvec
   en: Who is Pyvec
 
-entries:
-  - name: Martin Bílek
-    role: chair
-    github: martinbilek
-    twitter: ajtea
-    linkedin: martin-b%C3%ADlek-47699542
-    avatar: github
-
-  - name: Jiří Bartoň
-    role: board
-    github: whiskybar
-    twitter: lurkingideas
-    avatar: github
-
-  - name: Aleš Zoulek
-    role: board
-    github: aleszoulek
-    twitter: aleszoulek
-    linkedin: zoulek
-    avatar: github
-
-  - name: Jakub Vysoký
-    role: board
-    github: kvbik
-    twitter: kvbik
-    linkedin: jakubvysoky
-    avatar: github
-
-  - name: Vítězslav Pliska
-    role: board
-    github: whit
-    twitter: whiteck
-    linkedin: vitekpliska
-    avatar: github
-
-  - name: Robin Gottfried
-    role: board
-    github: czervenka
-    twitter: czervenka
-    linkedin: robingottfried
-    avatar: github
-
-  - name: Honza Král
-    role: board
-    github: honzakral
-    twitter: honzakral
-    linkedin: honzakral
-    avatar: github
-
-  - name: Martin Burián
-    role: trustee
-    twitter: martin_burian
-    linkedin: martinburi8n
-    avatar: twitter
-
-  - name: Filip Vařecha
-    role: trustee
-    github: xaralis
-    twitter: xaralis
-    linkedin: filip-vařecha-51625031
-    avatar: github
-
-  - name: Jiří Suchan
-    role: trustee
-    github: yedpodtrzitko
-    twitter: yedpodtrzitko
-    linkedin: yedpodtrzitko
-    avatar: twitter
-
 roles:
   chair:
     cs: předseda
@@ -78,9 +9,6 @@ roles:
   board:
     cs: člen rady
     en: board member
-  trustee:
-    cs: člen dozorčí rady
-    en: board of trustees member
 
 note:
   icon: user-circle-o

--- a/pyvecorg/data/members_list_schema.json
+++ b/pyvecorg/data/members_list_schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "entries": {
+      "type": "array",
+      "items": {
+        "$ref": "definitions/member_schema.json#"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "entries"
+  ]
+}

--- a/pyvecorg/data/members_schema.json
+++ b/pyvecorg/data/members_schema.json
@@ -5,12 +5,6 @@
     "heading": {
       "$ref": "definitions/translated_text_schema.json#"
     },
-    "entries": {
-      "type": "array",
-      "items": {
-        "$ref": "definitions/member_schema.json#"
-      }
-    },
     "roles": {
       "type": "object",
       "patternProperties": {
@@ -27,7 +21,6 @@
   "additionalProperties": false,
   "required": [
     "heading",
-    "entries",
     "roles",
     "note"
   ]

--- a/pyvecorg/templates/index.html
+++ b/pyvecorg/templates/index.html
@@ -155,7 +155,7 @@
             <ul class="list row members">
                 {% for member in members_list.entries %}
                 <li class="list-item member col">
-                    <img src="{{ member|avatar_url }}" alt="{{ member.name }}" width="100" class="rounded-circle member-avatar">
+                    <img src="{{ url_for('static', filename=member.avatar_filename) }}" alt="{{ member.name }}" width="100" class="rounded-circle member-avatar">
                     <p class="member-profiles">
                         {% if member.github %}
                         <a href="https://github.com/{{ member.github }}" title="GitHub" class="icon">

--- a/pyvecorg/templates/index.html
+++ b/pyvecorg/templates/index.html
@@ -152,46 +152,53 @@
             </ul>
 
             <h2 id="members">{{ members.heading }}</h2>
-            <ul class="list row members">
-                {% for member in members_list.entries %}
-                <li class="list-item member col">
-                    <img src="{{ url_for('static', filename=member.avatar_filename) }}" alt="{{ member.name }}" width="100" class="rounded-circle member-avatar">
-                    <p class="member-profiles">
-                        {% if member.github %}
-                        <a href="https://github.com/{{ member.github }}" title="GitHub" class="icon">
-                            <i class="fa fa-github" aria-hidden="true"></i><!--
-                            --><span>GitHub</span><!--
-                        --></a>
-                        {% endif %}
-                        {% if member.twitter %}
-                        <a href="https://twitter.com/{{ member.twitter }}" title="Twitter" class="icon">
-                            <i class="fa fa-twitter" aria-hidden="true"></i><!--
-                            --><span>Twitter</span><!--
-                        --></a>
-                        {% endif %}
-                        {% if member.linkedin %}
-                        <a href="https://linkedin.com/in/{{ member.linkedin }}" title="LinkedIn" class="icon">
-                            <i class="fa fa-linkedin" aria-hidden="true"></i><!--
-                            --><span>LinkedIn</span><!--
-                        --></a>
-                        {% endif %}
-                    </p>
-                    <p class="member-info">
-                        <strong class="member-name">{{ member.nickname|default(member.name) }}</strong><br>
-                        <small class="member-role">{{ members.roles[member.role] }}</small><br>
-                    </p>
-                </li>
-                {% if loop.index is divisibleby 2 %}
-                    <div class="w-100 d-block d-sm-none"></div>
-                {% endif %}
-                {% if loop.index is divisibleby 3 %}
-                    <div class="w-100 d-none d-sm-block d-md-none"></div>
-                {% endif %}
-                {% if loop.index is divisibleby 5 %}
-                    <div class="w-100 d-none d-md-block d-lg-block d-xl-block"></div>
-                {% endif %}
-                {% endfor %}
-            </ul>
+            {% if members_list %}
+                <ul class="list row members">
+                    {% for member in members_list.entries %}
+                    <li class="list-item member col">
+                        <img src="{{ url_for('static', filename=member.avatar_filename) }}" alt="{{ member.name }}" width="100" class="rounded-circle member-avatar">
+                        <p class="member-profiles">
+                            {% if member.github %}
+                            <a href="https://github.com/{{ member.github }}" title="GitHub" class="icon">
+                                <i class="fa fa-github" aria-hidden="true"></i><!--
+                                --><span>GitHub</span><!--
+                            --></a>
+                            {% endif %}
+                            {% if member.twitter %}
+                            <a href="https://twitter.com/{{ member.twitter }}" title="Twitter" class="icon">
+                                <i class="fa fa-twitter" aria-hidden="true"></i><!--
+                                --><span>Twitter</span><!--
+                            --></a>
+                            {% endif %}
+                            {% if member.linkedin %}
+                            <a href="https://linkedin.com/in/{{ member.linkedin }}" title="LinkedIn" class="icon">
+                                <i class="fa fa-linkedin" aria-hidden="true"></i><!--
+                                --><span>LinkedIn</span><!--
+                            --></a>
+                            {% endif %}
+                        </p>
+                        <p class="member-info">
+                            <strong class="member-name">{{ member.nickname|default(member.name) }}</strong><br>
+                            <small class="member-role">{{ members.roles[member.role] }}</small><br>
+                        </p>
+                    </li>
+                    {% if loop.index is divisibleby 2 %}
+                        <div class="w-100 d-block d-sm-none"></div>
+                    {% endif %}
+                    {% if loop.index is divisibleby 3 %}
+                        <div class="w-100 d-none d-sm-block d-md-none"></div>
+                    {% endif %}
+                    {% if loop.index is divisibleby 5 %}
+                        <div class="w-100 d-none d-md-block d-lg-block d-xl-block"></div>
+                    {% endif %}
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <p>
+                    Seznam členů se nepodařilo načíst.
+                    <!-- To fix this, you need to run 'pipenv run build' -->
+                </p>
+            {% endif %}
             <div class="media">
                 <div class="media-image">
                     <i class="fa fa-{{ members.note.icon }}" aria-hidden="true"></i>

--- a/pyvecorg/templates/index.html
+++ b/pyvecorg/templates/index.html
@@ -177,7 +177,7 @@
                         {% endif %}
                     </p>
                     <p class="member-info">
-                        <strong class="member-name">{{ member.name }}</strong><br>
+                        <strong class="member-name">{{ member.nickname|default(member.name) }}</strong><br>
                         <small class="member-role">{{ members.roles[member.role] }}</small><br>
                     </p>
                 </li>

--- a/pyvecorg/templates/index.html
+++ b/pyvecorg/templates/index.html
@@ -153,7 +153,7 @@
 
             <h2 id="members">{{ members.heading }}</h2>
             <ul class="list row members">
-                {% for member in members.entries %}
+                {% for member in members_list.entries %}
                 <li class="list-item member col">
                     <img src="{{ member|avatar_url }}" alt="{{ member.name }}" width="100" class="rounded-circle member-avatar">
                     <p class="member-profiles">

--- a/pyvecorg/templating.py
+++ b/pyvecorg/templating.py
@@ -2,7 +2,6 @@ import re
 import textwrap
 
 import jinja2
-import requests
 from markdown import markdown
 
 from pyvecorg import app

--- a/pyvecorg/templating.py
+++ b/pyvecorg/templating.py
@@ -3,9 +3,7 @@ import textwrap
 
 import jinja2
 import requests
-from slugify import slugify
 from markdown import markdown
-from flask import url_for
 
 from pyvecorg import app
 
@@ -15,11 +13,6 @@ def convert_markdown(text):
     text = textwrap.dedent(text)
     result = jinja2.Markup(markdown(text))
     return result
-
-
-@app.template_filter('avatar_url')
-def get_avatar_url(member):
-    return url_for('avatar', name=slugify(member['name']))
 
 
 @app.template_filter('url')

--- a/pyvecorg/views.py
+++ b/pyvecorg/views.py
@@ -1,15 +1,11 @@
 import os
-import io
 import platform
 from datetime import datetime
 
 from flask import (request, render_template, redirect, url_for,
-                   send_from_directory, jsonify, abort, send_file)
-from slugify import slugify
-import requests
+                   send_from_directory, jsonify)
 
 from pyvecorg import app
-from pyvecorg.avatars import get_avatar_url, create_thumbnail
 from pyvecorg.data import load_data, select_language
 
 
@@ -41,19 +37,3 @@ def index(lang):
 @app.route('/<lang>/api.json')
 def api(lang):
     return jsonify(select_language(data, lang))
-
-
-@app.route('/static/img/avatars/<name>.png')
-def avatar(name):
-    try:
-        member = [member for member in data['members_list']['entries']
-                  if slugify(member['name']) == name][0]
-    except IndexError:
-        abort(404)
-
-    response = requests.get(member['avatar_url'])
-    response.raise_for_status()
-    file = create_thumbnail(io.BytesIO(response.content), 100)
-
-    return send_file(file, mimetype='image/png', as_attachment=True,
-                           attachment_filename=f'{name}.png')

--- a/pyvecorg/views.py
+++ b/pyvecorg/views.py
@@ -2,8 +2,8 @@ import os
 import platform
 from datetime import datetime
 
-from flask import (request, render_template, redirect, url_for,
-                   send_from_directory, jsonify)
+from flask import (render_template, redirect, url_for, send_from_directory,
+                   jsonify)
 
 from pyvecorg import app
 from pyvecorg.data import load_data, select_language

--- a/pyvecorg/views.py
+++ b/pyvecorg/views.py
@@ -46,7 +46,7 @@ def api(lang):
 @app.route('/static/img/avatars/<name>.png')
 def avatar(name):
     try:
-        member = [member for member in data['members']['entries']
+        member = [member for member in data['members_list']['entries']
                   if slugify(member['name']) == name][0]
     except IndexError:
         abort(404)

--- a/pyvecorg/views.py
+++ b/pyvecorg/views.py
@@ -51,10 +51,9 @@ def avatar(name):
     except IndexError:
         abort(404)
 
-    url = get_avatar_url(member)
-    res = requests.get(url)
-    res.raise_for_status()
-    file = create_thumbnail(io.BytesIO(res.content), 100)
+    response = requests.get(member['avatar_url'])
+    response.raise_for_status()
+    file = create_thumbnail(io.BytesIO(response.content), 100)
 
     return send_file(file, mimetype='image/png', as_attachment=True,
                            attachment_filename=f'{name}.png')

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -110,35 +110,6 @@ def test_data_member_with_avatar_is_valid(member):
     assert member['avatar'] in ('github', 'twitter', 'email')
 
 
-@pytest.mark.parametrize('member', [
-    member for member in DATA['members_list']['entries']
-    if member.get('avatar') == 'github'
-])
-def test_data_member_has_valid_github_avatar(member):
-    assert member.get('github')
-    is_working_link(member['avatar_url'])
-
-
-@pytest.mark.parametrize('member', [
-    member for member in DATA['members_list']['entries']
-    if member.get('avatar') == 'twitter'
-])
-def test_data_member_has_valid_twitter_avatar(member):
-    assert member.get('twitter')
-    assert 'default_profile' not in member['avatar_url']
-    is_working_link(member['avatar_url'])
-
-
-@pytest.mark.parametrize('member', [
-    member for member in DATA['members_list']['entries']
-    if member.get('avatar') == 'email'
-])
-def test_data_member_has_valid_gravatar(member):
-    assert member.get('email')
-    assert '0000' not in member['avatar_url']
-    is_working_link(member['avatar_url'])
-
-
 @pytest.mark.parametrize('logo', frozenset(
     entry['logo'] for entry
     in (

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -63,14 +63,9 @@ def test_data_section_is_valid(section_name, section):
 
 
 @pytest.mark.parametrize('member', [
-    member for member in DATA['members']['entries']
+    member for member in DATA['members_list']['entries']
 ])
 def test_data_member_is_valid(member):
-    assert member['role'] in list(DATA['members']['roles'].keys())
-
-    assert member.get('avatar')
-    assert member['avatar'] in ('github', 'twitter', 'email')
-
     if member.get('email'):
         assert '@' in member['email']
     if member.get('linkedin'):
@@ -83,7 +78,17 @@ def test_data_member_is_valid(member):
 
 
 @pytest.mark.parametrize('member', [
-    member for member in DATA['members']['entries']
+    member for member in DATA['members_list']['entries']
+    if member.get('role')
+])
+def test_data_member_with_role_is_valid(member):
+    assert member['role'] in list(DATA['members']['roles'].keys())
+    assert member.get('avatar')
+    assert member['avatar'] in ('github', 'twitter', 'email')
+
+
+@pytest.mark.parametrize('member', [
+    member for member in DATA['members_list']['entries']
     if member.get('avatar') == 'github'
 ])
 def test_data_member_has_valid_github_avatar(member):
@@ -93,7 +98,7 @@ def test_data_member_has_valid_github_avatar(member):
 
 
 @pytest.mark.parametrize('member', [
-    member for member in DATA['members']['entries']
+    member for member in DATA['members_list']['entries']
     if member.get('avatar') == 'twitter'
 ])
 def test_data_member_has_valid_twitter_avatar(member):
@@ -104,7 +109,7 @@ def test_data_member_has_valid_twitter_avatar(member):
 
 
 @pytest.mark.parametrize('member', [
-    member for member in DATA['members']['entries']
+    member for member in DATA['members_list']['entries']
     if member.get('avatar') == 'email'
 ])
 def test_data_member_has_valid_gravatar(member):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -9,7 +9,6 @@ import jsonschema
 
 from pyvecorg.data import (load_data, select_language,
                            DATA_PATH, SUPPORTED_LANGS)
-from pyvecorg.avatars import get_avatar_url
 
 
 STATIC_PATH = os.path.join(DATA_PATH, '..', 'static')
@@ -64,17 +63,35 @@ def test_data_section_is_valid(section_name, section):
 
 @pytest.mark.parametrize('member', [
     member for member in DATA['members_list']['entries']
+    if member.get('email')
 ])
-def test_data_member_is_valid(member):
-    if member.get('email'):
-        assert '@' in member['email']
-    if member.get('linkedin'):
-        assert not member['linkedin'].startswith('http')
-    if member.get('github'):
-        assert not member['github'].startswith('http')
-    if member.get('twitter'):
-        assert not member['twitter'].startswith('http')
-        assert not member['twitter'].startswith('@')
+def test_data_member_with_email_is_valid(member):
+    assert '@' in member['email']
+
+
+@pytest.mark.parametrize('member', [
+    member for member in DATA['members_list']['entries']
+    if member.get('linkedin')
+])
+def test_data_member_with_linkedin_is_valid(member):
+    assert not member['linkedin'].startswith('http')
+
+
+@pytest.mark.parametrize('member', [
+    member for member in DATA['members_list']['entries']
+    if member.get('github')
+])
+def test_data_member_with_github_is_valid(member):
+    assert not member['github'].startswith('http')
+
+
+@pytest.mark.parametrize('member', [
+    member for member in DATA['members_list']['entries']
+    if member.get('twitter')
+])
+def test_data_member_with_twitter_is_valid(member):
+    assert not member['twitter'].startswith('http')
+    assert not member['twitter'].startswith('@')
 
 
 @pytest.mark.parametrize('member', [
@@ -83,7 +100,13 @@ def test_data_member_is_valid(member):
 ])
 def test_data_member_with_role_is_valid(member):
     assert member['role'] in list(DATA['members']['roles'].keys())
-    assert member.get('avatar')
+
+
+@pytest.mark.parametrize('member', [
+    member for member in DATA['members_list']['entries']
+    if member.get('avatar')
+])
+def test_data_member_with_avatar_is_valid(member):
     assert member['avatar'] in ('github', 'twitter', 'email')
 
 
@@ -93,8 +116,7 @@ def test_data_member_with_role_is_valid(member):
 ])
 def test_data_member_has_valid_github_avatar(member):
     assert member.get('github')
-    url = get_avatar_url(member)
-    is_working_link(url)
+    is_working_link(member['avatar_url'])
 
 
 @pytest.mark.parametrize('member', [
@@ -103,9 +125,8 @@ def test_data_member_has_valid_github_avatar(member):
 ])
 def test_data_member_has_valid_twitter_avatar(member):
     assert member.get('twitter')
-    url = get_avatar_url(member)
-    is_working_link(url)
-    assert 'default_profile' not in url
+    assert 'default_profile' not in member['avatar_url']
+    is_working_link(member['avatar_url'])
 
 
 @pytest.mark.parametrize('member', [
@@ -114,8 +135,8 @@ def test_data_member_has_valid_twitter_avatar(member):
 ])
 def test_data_member_has_valid_gravatar(member):
     assert member.get('email')
-    url = get_avatar_url(member)
-    is_working_link(url)
+    assert '0000' not in member['avatar_url']
+    is_working_link(member['avatar_url'])
 
 
 @pytest.mark.parametrize('logo', frozenset(


### PR DESCRIPTION
This change introduces a new separate step needed for development and deployment of the site - `pipenv run build`, which downloads data from external sources. Even though the site is serialized into a static HTML so one might think doing it in Flask views is not a problem, I think this is a better solution, because I can run `pipenv run build` just once and then develop the site with fast refreshing or even offline.

In this PR I introduce downloading of members list from a spreadsheet saved in Pyvec Google Drive. It updates the board members according to the latest changes. When I was at it, I also moved all avatar handling into the build step - no more proxy views to make thumbnails etc. Now all avatars are downloaded to a directory inside `static` as PNG images during the build step.