### PR TITLE
Přidání odkazu na dokumentaci

### DIFF
--- a/pyvecorg/data/projects.yml
+++ b/pyvecorg/data/projects.yml
@@ -176,7 +176,7 @@ note:
     en: Volunteer
   text:
     cs: |-
-      Pyvec nikomu **neříká, co má dělat**. Pomáhá těm, kteří se o něco snaží
+      Pyvec nikomu **neříká, co má dělat**. [Pomáhá těm, kteří se o něco snaží](https://docs.pyvec.org/operations/support.html)
       &mdash; je to **servisní organizace**. Založení srazu ve tvém městě? Kurz
       na tvé škole? Workshop? Screencast? Pojďmě spolu vymyslet, jak
       to zrealizovat! Ozvi se nám na [info@pyvec.org](mailto:info@pyvec.org).


### PR DESCRIPTION
Do EN verze jsem odkaz nepřidal, protože text v dokumentaci je česky.