### PR TITLE
Přidání zásad zpracování osobních údajů

### DIFF
--- a/pyvecorg/data/privacy_policy.yml
+++ b/pyvecorg/data/privacy_policy.yml
@@ -1,0 +1,7 @@
+title:
+  cs: Zpracování osobních údajů
+  en: Privacy Policy
+
+text:
+  cs: TBD
+  en: TBD

--- a/pyvecorg/data/privacy_policy.yml
+++ b/pyvecorg/data/privacy_policy.yml
@@ -3,5 +3,16 @@ title:
   en: Privacy Policy
 
 text:
-  cs: TBD
-  en: TBD
+  cs: |
+    Správcem osobních údajů je Pyvec, z.s., IČO: 22746668, se sídlem Drtinova 10/557, Praha. Můžete jej kontaktovat na [info@pyvec.org](mailto:info@pyvec.org).
+
+    Pyvec, z.s., dále jen „Spolek“, udržuje neveřejný seznam svých členů, který obsahuje i jejich jméno, přezdívku, e-mail, datum narození, adresu a odkazy na jejich internetové profily. Pokud osobě zanikne členství, údaje o ní jsou smazány a nejsou nadále uchovávány. Členové mohou Spolku individuálně udělit nebo odebrat souhlas s uveřejněním ve veřejném seznamu členů, který se může nacházet na těchto stránkách. E-mailová a poštovní adresa slouží Spolku pouze k tomu, aby mohl členy kontaktovat za účelem naplňování [povinností, jež mu ukládají stanovy](https://docs.pyvec.org/operations/bylaws.html).
+
+    Spolek pro shromažďování a uchovávání osobních údajů o členech využívá [Google Docs](https://docs.google.com/). Osobní údaje uchovává společnost Google LLC na základě svých [zásad ochrany osobních údajů](https://policies.google.com/privacy). Uživatelský přístup k datům mají pouze členové výboru Spolku.
+
+  en: |
+    This privacy policy applies to Pyvec, z.s., a nonprofit with a registration number 22746668 and registered office at Drtinova 10/557, Prague, Czech Republic. You can contact Pyvec, z.s. at [info@pyvec.org](mailto:info@pyvec.org).
+
+    Pyvec, z.s. maintains a private list of its members, which contains their name, nickname, email, date of birth, address, and links to their public internet profiles. If person's membership ends, Pyvec, z.s. deletes all data about the person it has collected. Members of Pyvec, z.s. can individually give or remove consent with being present in a public list of memebers, which can appear at this website. Pyvec, z.s. can use the collected emails and addresses only to contact the members in order to fulfill [requirements given by the bylaws](https://docs.pyvec.org/operations/bylaws.html).
+
+    Pyvec, z.s. uses [Google Docs](https://docs.google.com/) to collect the personal information. Company Google LLC keeps the data according to terms in [their own privacy policy](https://policies.google.com/privacy). Only Pyvec, z.s. board members have user access to the data.

--- a/pyvecorg/data/privacy_policy_schema.json
+++ b/pyvecorg/data/privacy_policy_schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "title": {
+      "$ref": "definitions/translated_text_schema.json#"
+    },
+    "text": {
+      "$ref": "definitions/translated_text_schema.json#"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "title",
+    "text"
+  ]
+}

--- a/pyvecorg/static/main.css
+++ b/pyvecorg/static/main.css
@@ -7,17 +7,6 @@ a:hover, a:focus {
     box-shadow: inset 0 0 0 rgba(0, 151, 223, 0), 0 2px 0 rgba(0, 151, 223, 1);
 }
 
-h1 img {
-    height: 2rem;
-}
-
-h1 {
-    margin: 0;
-    padding: 1rem 0;
-    line-height: 2rem;
-    vertical-align: middle;
-}
-
 .lang {
     margin: 0;
     line-height: 4rem;
@@ -45,20 +34,40 @@ h1 {
     box-shadow: inset 0 0 0 rgba(51, 122, 183, 0), 0 2px 0 rgba(255, 255, 255, 1);
 }
 
-h2 {
+.header h1 a, .header h1 a:hover, .header h1 a:focus {
+    box-shadow: none;
+}
+
+h1 img {
+    height: 2rem;
+}
+
+h1 {
+    margin: 0;
+    padding: 1rem 0;
+    line-height: 2rem;
+    vertical-align: middle;
+}
+
+.page-index h2 {
     font-size: 0.8rem;
     font-weight: normal;
     text-transform: uppercase;
     text-align: center;
     letter-spacing: 0.3em;
-    margin: 5rem 0;
     padding-bottom: 1rem;
     border-bottom: 2px solid #212529;
 }
 
-h3 {
+.page-index h3,
+.page h2 {
     font-size: 1.5rem;
     margin-bottom: 0 0 0.5rem 0;
+}
+
+.page-index h2,
+.page h2 {
+    margin: 5rem 0;
 }
 
 h4 {
@@ -264,6 +273,11 @@ a.icon, a.icon:hover, a.icon:focus,
 .profiles .icon {
     font-size: 2rem;
     margin: 1rem;
+}
+
+.extra-pages {
+    font-size: 80%;
+    text-align: right;
 }
 
 .downloads a {

--- a/pyvecorg/templates/index.html
+++ b/pyvecorg/templates/index.html
@@ -26,18 +26,21 @@
             <div class="container">
                 <div class="row">
                     <h1 class="col">
-                        <img height="50" src="{{ url_for('static', filename='img/pyvec.svg') }}" alt="Pyvec">
+                        <a href="{{ url_for('index', lang=lang)}}">
+                            <img height="50" src="{{ url_for('static', filename='img/pyvec.svg') }}" alt="Pyvec">
+                        </a>
                     </h1>
                     <p class="lang col">
                         {% if lang == 'cs' %}
-                            <a href="{{ url_for('index', lang='en') }}">English</a>
+                            <a href="{{ url_for(this, lang='en') }}">English</a>
                         {% elif lang == 'en' %}
-                            <a href="{{ url_for('index', lang='cs') }}">Česky</a>
+                            <a href="{{ url_for(this, lang='cs') }}">Česky</a>
                         {% endif %}
                     </p>
                 </div>
             </div>
         </div>
+        {% block cover %}
         <div class="cover">
             <div class="cover-black">
                 <div class="container">
@@ -63,7 +66,9 @@
                 </div>
             </div>
         </div>
-        <div class="container">
+        {% endblock %}
+        {% block content %}
+        <div class="container page-index">
             <h2 id="numbers">{{ numbers.heading }}</h2>
             <p class="numbers">
                 {% for number in numbers.entries %}
@@ -209,6 +214,7 @@
                 </div>
             </div>
         </div>
+        {% endblock %}
         <div class="footer">
             <div class="container">
                 <div class="row">
@@ -273,6 +279,9 @@
                             </li>
                             {% endfor %}
                         </ul>
+                        <p class="extra-pages">
+                            <a href="{{ url_for('privacy_policy', lang=lang) }}">{{ privacy_policy.heading }}</a>
+                        </p>
                     </div>
                 </div>
             </div>

--- a/pyvecorg/templates/privacy_policy.html
+++ b/pyvecorg/templates/privacy_policy.html
@@ -1,0 +1,10 @@
+{% extends "index.html" %}
+
+{% block cover %}{% endblock %}
+
+{% block content %}
+    <div class="container page">
+        <h2>{{ privacy_policy.title }}</h2>
+        {{ privacy_policy.text|markdown }}
+    </div>
+{% endblock %}

--- a/pyvecorg/views.py
+++ b/pyvecorg/views.py
@@ -31,7 +31,17 @@ def index(lang):
     context = select_language(data, lang)
     context['lang'] = lang
     context['now'] = datetime.now()
+    context['this'] = 'index'
     return render_template('index.html', **context)
+
+
+@app.route('/en/privacy-policy/', defaults={'lang': 'en'})
+@app.route('/cs/zpracovani-osobnich-udaju/', defaults={'lang': 'cs'})
+def privacy_policy(lang):
+    context = select_language(data, lang)
+    context['lang'] = lang
+    context['this'] = 'privacy_policy'
+    return render_template('privacy_policy.html', **context)
 
 
 @app.route('/<lang>/api.json')


### PR DESCRIPTION
Nastřelil jsem zpracování osobních údajů členů Pyvce, což je něco, co zmiňují i stanovy, ale ještě to nemáme - fixes #99. Mým cílem nebylo vytvořit právně neprůstřelný text, ale vytvořit lidsky čitelný odstavec, který naplňuje smysl GDPR. [Totožně jsem k tomu přistoupil v případě JG](https://junior.guru/privacy/) a zatím se na mě žádné žaloby nesesypaly. Nemyslím si, že je toto vyloženě práce pro právníky a nemyslím si, že cílem GDPR bylo, aby se tyto texty daly produkovat jen s právníky za zády, ale klidně mě přehlasujte.

Překlad do angličtiny je můj, amatérský. Vlastně nevím, jestli ho tam vůbec mít, je velmi nepravděpodobné, že někdo, kdo nerozumí česky, se může momentálně stát členem Pyvce, ale tak zkusil jsem něco vyplodit. Osobně bych byl pro, abychom anglickou verzi raději odstranili, než abychom nad ní třeba strávili hodiny jejím upravováním.

Budu rád za názory!

P.S.: Díky @aleszoulek za velkou inspiraci, jak udělat technické zpracování. Hodně jsem opisoval z jeho https://github.com/pyvec/pyvec.org/pull/33/.