### PR TITLE
Mention our non-profit status

### DIFF
--- a/pyvecorg/data/meta.yml
+++ b/pyvecorg/data/meta.yml
@@ -4,10 +4,10 @@ title:
 
 claim:
   cs: >-
-    Jsme servisní&nbsp;organizace české&nbsp;komunity<br>
+    Jsme nezisková servisní&nbsp;organizace české&nbsp;komunity<br>
     kolem programovacího jazyka&nbsp;[Python](https://python.cz/)
   en: >-
-    Service organization of&nbsp;the&nbsp;Czech<br>
+    Service non-profit organization of&nbsp;the&nbsp;Czech<br>
     [Python](https://python.cz/en/)&nbsp;programming&nbsp;language user&nbsp;group
 
 billing_address:

--- a/pyvecorg/data/projects.yml
+++ b/pyvecorg/data/projects.yml
@@ -177,7 +177,7 @@ note:
   text:
     cs: |-
       Pyvec nikomu **neříká, co má dělat**. [Pomáhá těm, kteří se o něco snaží](https://docs.pyvec.org/operations/support.html)
-      &mdash; je to **servisní organizace**. Založení srazu ve tvém městě? Kurz
+      &mdash; je to nezisková **servisní organizace**. Založení srazu ve tvém městě? Kurz
       na tvé škole? Workshop? Screencast? Pojďmě spolu vymyslet, jak
       to zrealizovat! Ozvi se nám na [info@pyvec.org](mailto:info@pyvec.org).
     en: |-


### PR DESCRIPTION
Currently it's only mentioned in the tab title of the page, but when
somebody does a page search (Ctrl+F), nothing is found.