### PR TITLE
supporters: fix Fragaria URL

### DIFF
--- a/pyvecorg/data/supporters.yml
+++ b/pyvecorg/data/supporters.yml
@@ -5,7 +5,7 @@ heading:
 entries:
   - name: Fragaria
     logo: img/supporters/fragaria.svg
-    url: https://www.fragaria.cz/
+    url: https://fragaria.cz/
 
   - name: Roští.cz
     logo: img/supporters/rosticz.png


### PR DESCRIPTION
www.fragaria.cz doesn't work anymore and breaks tests.