### PR TITLE
Update footer: show only single address

### DIFF
--- a/pyvecorg/data/meta.yml
+++ b/pyvecorg/data/meta.yml
@@ -20,11 +20,11 @@ billing_address:
     cs: >-
       Pyvec, z.s.<br>
       Korunní&nbsp;2569/108<br>
-      101&nbsp;00 Praha&nbsp;10 &ndash; Vinohrady
+      101&nbsp;00 Praha&nbsp;10
     en: >-
       Pyvec, z.s.<br>
       Korunní&nbsp;2569/108<br>
-      101&nbsp;00 Prague&nbsp;10 &ndash; Vinohrady<br>
+      101&nbsp;00 Prague&nbsp;10<br>
       Czech Republic, EU
 
 address:
@@ -35,11 +35,11 @@ address:
     cs: >-
       Pyvec, z.s.<br>
       Korunní&nbsp;2569/108<br>
-      101&nbsp;00 Praha&nbsp;10 &ndash; Vinohrady
+      101&nbsp;00 Praha&nbsp;10
     en: >-
       Pyvec, z.s.<br>
       Korunní&nbsp;2569/108<br>
-      101&nbsp;00 Prague&nbsp;10 &ndash; Vinohrady<br>
+      101&nbsp;00 Prague&nbsp;10<br>
       Czech Republic, EU
 
 reg_no:

--- a/pyvecorg/data/meta.yml
+++ b/pyvecorg/data/meta.yml
@@ -16,7 +16,7 @@ billing_address:
   heading:
     cs: Fakturační adresa
     en: Billing address
-  directions:
+  directions: &address
     cs: >-
       Pyvec, z.s.<br>
       Korunní&nbsp;2569/108<br>
@@ -31,16 +31,7 @@ address:
   heading:
     cs: Adresa
     en: Address
-  directions:
-    cs: >-
-      Pyvec, z.s.<br>
-      Korunní&nbsp;2569/108<br>
-      101&nbsp;00 Praha&nbsp;10
-    en: >-
-      Pyvec, z.s.<br>
-      Korunní&nbsp;2569/108<br>
-      101&nbsp;00 Prague&nbsp;10<br>
-      Czech Republic, EU
+  directions: *address
 
 reg_no:
   label:

--- a/pyvecorg/data/meta.yml
+++ b/pyvecorg/data/meta.yml
@@ -10,6 +10,8 @@ claim:
     Service non-profit organization of&nbsp;the&nbsp;Czech<br>
     [Python](https://python.cz/en/)&nbsp;programming&nbsp;language user&nbsp;group
 
+# Billing address is not used in the template, but it was part of the JSON API response.
+# Keeping it does not hurt us, therefore we should keep it for compatibility.
 billing_address:
   heading:
     cs: Fakturační adresa
@@ -32,12 +34,12 @@ address:
   directions:
     cs: >-
       Pyvec, z.s.<br>
-      Ječná 507/6<br>
-      12000 Praha 2
+      Korunní&nbsp;2569/108<br>
+      101&nbsp;00 Praha&nbsp;10 &ndash; Vinohrady
     en: >-
       Pyvec, z.s.<br>
-      Ječná 507/6<br>
-      12000 Prague<br>
+      Korunní&nbsp;2569/108<br>
+      101&nbsp;00 Prague&nbsp;10 &ndash; Vinohrady<br>
       Czech Republic, EU
 
 reg_no:

--- a/pyvecorg/static/main.css
+++ b/pyvecorg/static/main.css
@@ -155,9 +155,14 @@ h4 {
 }
 
 a.icon, a.icon:hover, a.icon:focus,
-.icon a, .icon:hover a, .icon:focus a {
+.icon a, .icon:hover a, .icon:focus a,
+a i.link-icon, a:hover i.link-icon, a:focus i.link-icon {
     text-decoration: none;
     box-shadow: none;
+}
+
+a i.link-icon {
+    margin-right: 1ex;
 }
 
 .icon span {
@@ -258,6 +263,20 @@ a.icon, a.icon:hover, a.icon:focus,
 .address {
     font-size: 80%;
     padding: 2rem 1rem 2rem 0.5rem;
+}
+
+/*
+ Decrease vertical paddings on mobile to give more condensed look.
+ max-width breakpoint taken from Bootstrap Docs:
+
+ https://getbootstrap.com/docs/4.6/layout/overview/#responsive-breakpoints
+ (see We occasionally use media queries that go in the other direction (the given screen size or smaller):)
+ */
+@media (max-width: 767.98px) {
+    .address {
+        padding-top: 1rem;
+        padding-bottom: 0rem;
+    }
 }
 
 .address h3 {

--- a/pyvecorg/templates/index.html
+++ b/pyvecorg/templates/index.html
@@ -12,7 +12,7 @@
         <meta property="twitter:creator" content="@pyvec">
 
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
-        <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}">
+        <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}?v=2024-08-05">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fork-awesome@1.2.0/css/fork-awesome.min.css" integrity="sha256-XoaMnoYC5TH6/+ihMEnospgm0J1PM/nioxbOUdnM8HY=" crossorigin="anonymous">
 
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -281,16 +281,44 @@
                         <h3>{{ meta.address.heading }}</h3>
                         {{ meta.address.directions|markdown }}
                         <p>
-                            E-mail: <a href="mailto:info@pyvec.org">info@pyvec.org</a>
+                            {{ meta.reg_no.label }}: <a href="{{ meta.reg_no.link }}">{{ meta.reg_no.value }}</a><br>
+                            {{ meta.databox_no.label }}: {{ meta.databox_no.value }}
                         </p>
+                        <p>E-mail: <a href="mailto:info@pyvec.org">info@pyvec.org</a></p>
                     </div>
                     <div class="w-100 d-block d-md-none"></div>
                     <div class="col address">
-                        <h3>{{ meta.billing_address.heading }}</h3>
-                        {{ meta.billing_address.directions|markdown }}
-                        <p>
-                            {{ meta.reg_no.label }}: <a href="{{ meta.reg_no.link }}">{{ meta.reg_no.value }}</a><br>
-                            {{ meta.databox_no.label }}: {{ meta.databox_no.value }}<br>
+                        <h3>{{ meta.downloads.heading }}</h3>
+                        <p class="downloads">
+                            <a href="{{ url_for('static', filename='bylaws-2024-01-23.pdf') }}">
+                                <i class="link-icon fa fa-file-pdf-o" aria-hidden="true"></i>
+                                {{- meta.downloads.bylaws }}.pdf
+                                {# {{- removes the whitespace between icon and the text, otherwise the white space would be underlined #}
+                            </a>
+                            <br>
+
+                            <a href="https://docs.pyvec.org/operations/bylaws.html">
+                                <i class="link-icon fa fa-file-o" aria-hidden="true"></i>
+                                {{- meta.downloads.bylaws }}
+                            </a>
+                            <br>
+
+                            <a href="https://or.justice.cz/ias/ui/vypis-sl-firma?subjektId=760829">
+                                <i class="link-icon fa fa-archive" aria-hidden="true"></i>
+                                {{- meta.downloads.filing }}
+                            </a>
+                            <br>
+
+                            <a href="https://github.com/pyvec/resources">
+                                <i class="link-icon fa fa-file-image-o" aria-hidden="true"></i>
+                                {{- meta.downloads.resources }}
+                            </a>
+                            <br>
+
+                            <a href="{{ url_for('api', lang=lang) }}">
+                                <i class="link-icon fa fa-file-code-o" aria-hidden="true"></i>
+                                {{- meta.downloads.json_data }}
+                            </a>
                         </p>
                     </div>
                     <div class="w-100 d-block d-md-none"></div>
@@ -306,25 +334,6 @@
                                 {{ meta.bank_account.bank_name }}<br>
                                 <a href="https://ib.fio.cz/ib/transparent?a={{ meta.bank_account.number }}&amp;l=ENGLISH">Transaction history</a>
                             {% endif %}
-                        </p>
-                        <h3>{{ meta.downloads.heading }}</h3>
-                        <p class="downloads">
-                            <i class="fa fa-file-pdf-o" aria-hidden="true"></i>
-                            <a href="{{ url_for('static', filename='bylaws-2024-01-23.pdf') }}">{{ meta.downloads.bylaws }}.pdf</a>
-
-                            <i class="fa fa-file-o" aria-hidden="true"></i>
-                            <a href="https://docs.pyvec.org/operations/bylaws.html">{{ meta.downloads.bylaws }}</a>
-
-                            <i class="fa fa-archive" aria-hidden="true"></i>
-                            <a href="https://or.justice.cz/ias/ui/vypis-sl-firma?subjektId=760829">{{ meta.downloads.filing }}</a>
-
-                            <br>
-
-                            <i class="fa fa-file-image-o" aria-hidden="true"></i>
-                            <a href="https://github.com/pyvec/resources">{{ meta.downloads.resources }}</a>
-
-                            <i class="fa fa-file-code-o" aria-hidden="true"></i>
-                            <a href="{{ url_for('api', lang=lang) }}">{{ meta.downloads.json_data }}</a>
                         </p>
                     </div>
                     <div class="w-100 d-block d-md-none"></div>


### PR DESCRIPTION
Při první úpravě jsem se zaměřil hlavně na tu fakturační adresu a tu druhou nezměnil. Patičku jsem tedy upravil, aby tam byla jen jedna adresa. Zároveň jsem jí o trošku přeskládal, aby to vypadalo lépe, udělal jsem ikonky u souborů ke stažení klikatelné a vyladil bílé místo na mobilu.

Nová podoba patičky:

![Pyvec neziskovka české Python komunity - Vivaldi-2024-08-05-13-02-16](https://github.com/user-attachments/assets/c0771391-dec2-42ad-ab3c-7584700a658a)