### PR TITLE
Pin older setuptools on CI

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -28,6 +28,7 @@ pipfile = "*"
 pylama = "*"
 pytest = "*"
 jsonschema = "*"
+setuptools = "<82"  # pylama uses pkg_resources
 
 [requires]
 python_version = "3.9"


### PR DESCRIPTION
      File "/home/runner/.local/share/virtualenvs/pyvec.org-2VXTcEni/lib/python3.9/site-packages/pylama/lint/__init__.py", line 10, in <module>
        from pkg_resources import iter_entry_points
    ModuleNotFoundError: No module named 'pkg_resources'